### PR TITLE
ENT-1907: Use Gradle's dependency substitution.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,13 @@ allprojects {
     group 'com.example'
     version '1.0-SNAPSHOT'
 
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        jcenter()
+        maven { url "https://jitpack.io" }
+    }
+
     cordapp {
         info {
             vendor = 'Cordapp Supplier'

--- a/build.gradle
+++ b/build.gradle
@@ -35,13 +35,6 @@ allprojects {
     group 'com.example'
     version '1.0-SNAPSHOT'
 
-    repositories {
-        mavenLocal()
-        mavenCentral()
-        jcenter()
-        maven { url "https://jitpack.io" }
-    }
-
     cordapp {
         info {
             vendor = 'Cordapp Supplier'

--- a/contract/build.gradle
+++ b/contract/build.gradle
@@ -4,10 +4,9 @@ apply plugin: 'kotlin-allopen'
 apply from: '../deterministic.gradle'
 
 dependencies {
-    cordaCompile "$corda_release_group:corda-serialization-deterministic:$corda_release_version"
-    cordaCompile("$corda_release_group:corda-jackson:$corda_release_version") {
-        exclude group: corda_release_group
-    }
+    cordaCompile "$corda_release_group:corda-jackson:$corda_release_version"
+    cordaCompile "$corda_release_group:corda-serialization:$corda_release_version"
+    cordaCompile "$corda_release_group:corda-core:$corda_release_version"
     cordaCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     cordaCompile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compileOnly "org.hibernate:hibernate-core:$hibernate_version"

--- a/deterministic.gradle
+++ b/deterministic.gradle
@@ -17,6 +17,16 @@ configurations {
     jdk.resolutionStrategy {
         cacheChangingModulesFor 0, 'seconds'
     }
+
+    all {
+        if (it.state == Configuration.State.UNRESOLVED) {
+            // Ensure that this module uses the deterministic Corda artifacts.
+            resolutionStrategy.dependencySubstitution {
+                substitute module("$corda_release_group:corda-serialization:$corda_release_version") with module("$corda_release_group:corda-serialization-deterministic:$corda_release_version")
+                substitute module("$corda_release_group:corda-core:$corda_release_version") with module("$corda_release_group:corda-core-deterministic:$corda_release_version")
+            }
+        }
+    }
 }
 
 dependencies {

--- a/flow/build.gradle
+++ b/flow/build.gradle
@@ -11,10 +11,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
 }
 
-configurations.compile {
-    exclude group: 'ch.qos.logback'
-}
-
 jar {
     baseName "${rootProject.name}-flow"
 }

--- a/flow/build.gradle
+++ b/flow/build.gradle
@@ -2,9 +2,7 @@ apply plugin: 'kotlin'
 apply plugin: 'net.corda.plugins.quasar-utils'
 
 dependencies {
-    cordapp(project(':contract')) {
-        transitive = false
-    }
+    cordapp(project(':contract'))
     cordaCompile "$corda_release_group:corda-node-api:$corda_release_version"
     cordaCompile "$corda_release_group:corda-confidential-identities:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"

--- a/flow/src/main/kotlin/com/example/goody/GoodyOps.kt
+++ b/flow/src/main/kotlin/com/example/goody/GoodyOps.kt
@@ -84,7 +84,8 @@ object GoodyOps {
         templateStates.map { entry ->
             val outputState = deriveState(
                 entry.value,
-                Amount(totalCandies[entry.key] ?: 0, Issued(entry.key, targetAmount.token)), recipient
+                Amount(totalCandies[entry.key] ?: 0, Issued(entry.key, targetAmount.token)),
+                recipient
             )
             tx.addOutputState(outputState)
         }

--- a/web/src/main/kotlin/com/example/goody/api/GoodyApi.kt
+++ b/web/src/main/kotlin/com/example/goody/api/GoodyApi.kt
@@ -13,7 +13,6 @@ import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
 import net.corda.core.messaging.vaultQueryBy
 import net.corda.core.node.services.vault.QueryCriteria
-import net.corda.core.node.services.Vault.StateModificationStatus.MODIFIABLE
 import net.corda.core.node.services.vault.builder
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.loggerFor
@@ -150,7 +149,7 @@ class GoodyApi(private val rpcOps: CordaRPCOps) {
             if (candyType != null) {
                 val candyIndex = builder { GoodySchemaV1.PersistentGoodyState::type.equal(candyType.toUpperCase()) }
                 // This query should only return states the calling node is a participant of (meaning they can be modified/spent).
-                sumCriteria.and(QueryCriteria.VaultCustomQueryCriteria(candyIndex, isModifiable = MODIFIABLE))
+                sumCriteria.and(QueryCriteria.VaultCustomQueryCriteria(candyIndex))
             } else {
                 sumCriteria
             }


### PR DESCRIPTION
Use Gradle's dependency substitution to replace non-deterministic Corda artifacts with deterministic ones - for deterministic modules only.